### PR TITLE
Stabilise smoke/fast/full runs, add bootstrap CIs, profile-specific outputs, and 2 d.p. formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,27 @@
 # wordle-strategies
 
-
 ## Quickstart
 ```bash
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
-python -m src.cli run --profile fast_dev
-python -m src.cli figures
-# for final numbers:
-python -m src.cli run --profile full_benchmark
-python -m src.cli figures
+```
+
+### Profiles
+- **Smoke** (seconds): sanity-check the pipeline  
+  `python -m src.cli run --profile smoke`
+
+- **Fast** (dev benchmark; with 95% CIs + plots):  
+  `python -m src.cli run --profile fast`
+
+- **Full** (full 2309-word sweep; with 95% CIs + plots):  
+  `python -m src.cli run --profile full`
+
+### Outputs
+`results/summary/`
+- `games_<mode>.csv` – per-game rows
+- `metrics_<mode>.csv` – per-solver metrics (2 d.p.)
+- `metrics_with_cis_<mode>.csv` – per-solver metrics with bootstrap 95% CIs (2 d.p.)
+
+`results/plots/`
+- `solver_bars_<mode>.png` (uses CIs if available)
+

--- a/config/fast.yaml
+++ b/config/fast.yaml
@@ -1,0 +1,10 @@
+mode: fast
+n_targets: 200
+repeats: 50
+workers: 1
+solvers: ["random", "heuristic", "entropy"]
+log_turns: false
+write_ci: true
+make_plots: true
+results_dir: results/summary
+

--- a/config/full.yaml
+++ b/config/full.yaml
@@ -1,0 +1,10 @@
+mode: full
+n_targets: all
+repeats: 1
+workers: 1
+solvers: ["random", "heuristic", "entropy"]
+log_turns: false
+write_ci: true
+make_plots: true
+results_dir: results/summary
+

--- a/config/smoke.yaml
+++ b/config/smoke.yaml
@@ -1,10 +1,10 @@
-mode: fast
-# tiny subset for quick smoke test
-fast_n_targets: 5
-fast_repeats: 1
-full_repeats: 1
-hard_mode: false
-allow_probes: false
-solvers: [random, heuristic]
-mcts: { rollouts_per_move: 5, ucb_c: 1.4 }
-analysis: { log_turns: false, topk: 3 }
+mode: smoke
+n_targets: 10
+repeats: 1
+workers: 1
+solvers: ["random"]
+log_turns: false
+write_ci: false
+make_plots: false
+results_dir: results/summary
+

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,23 +1,22 @@
-# src/cli.py
-import argparse, os
+import argparse
+
 from .runner import run_profile
 
+
 def main():
-    ap = argparse.ArgumentParser()
-    sub = ap.add_subparsers(dest="cmd", required=True)
+    p = argparse.ArgumentParser()
+    p.add_argument("cmd", nargs="?", default="run", choices=["run", "figures"])
+    p.add_argument("--profile", default="smoke")
+    args = p.parse_args()
 
-    r = sub.add_parser("run")
-    r.add_argument("--profile", default=os.environ.get("WORDLE_PROFILE", "fast_dev"))
-
-    sub.add_parser("figures")
-
-    args = ap.parse_args()
     if args.cmd == "run":
         run_profile(args.profile)
     else:
-        # figures command
-        from .analysis import make_all_figures
-        make_all_figures()
+        from .figures import build_all
+
+        build_all(mode=args.profile, results_dir="results/summary")
+
 
 if __name__ == "__main__":
     main()
+

--- a/src/eval.py
+++ b/src/eval.py
@@ -1,279 +1,246 @@
-"""Game evaluation utilities for Wordle solvers.
-
-This module contains helpers for running solvers against a set of
-Wordle targets and collecting aggregate statistics.  The original file
-in the repository had a partially copied notebook with duplicated and
-unfinished code which resulted in import errors when the CLI attempted
-to import ``summarize_with_cis`` from here.  The rewritten module below
-provides a minimal but functional implementation.
-"""
-
 from __future__ import annotations
 
-import collections
+from pathlib import Path
 import csv
-import itertools
-import json
-import os
 import random
-import statistics
-from dataclasses import dataclass
-from typing import List
-
 import numpy as np
 import pandas as pd
-from tqdm import tqdm
 
-from .config import get_config, config_paths
-from .wordle_core import cached_pattern, consistent, target_words, all_valid_words
+from .wordle_core import (
+    cached_pattern,
+    consistent,
+    target_words,
+    all_valid_words,
+)
 from .solvers import Solver
 
 
-def _summary_dir() -> str:
-    return str(config_paths()["summary"])
+# Defaults (runner can overwrite)
+RESULTS_DIR = Path("results/summary")
+RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+
+TURNLOG_CSV = RESULTS_DIR / "turnlog.csv"
+GAMES_CSV = RESULTS_DIR / "games.csv"    # per-game rows
+METRICS_CSV = RESULTS_DIR / "metrics.csv"  # per-solver summary
+
+LOG_TURNS = False  # over-ridden per profile
 
 
-def _turnlog_csv() -> str:
-    cfg = get_config()
-    return os.path.join(_summary_dir(), f"turnlog_{cfg['mode']}.csv")
-
-
-@dataclass
-class GameResult:
-    """Result of a single game of Wordle."""
-
-    solver: str
-    target: str
-    success: bool
-    guesses: int
-    sequence: List[str]
-
-
-def _maybe_init_turnlog() -> None:
-    """Create the per-turn log file with a header if logging is enabled."""
-
-    cfg = get_config()
-    if not cfg["analysis"]["log_turns"]:
+# --- per-turn logging (safe/no-op in smoke) ---
+def append_turn_log(row: dict):
+    if not LOG_TURNS:
         return
-    path = _turnlog_csv()
-    if os.path.exists(path):
-        return
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w", newline="") as f:
-        writer = csv.writer(f)
-        writer.writerow(
-            [
-                "game_id",
-                "solver",
-                "turn",
-                "target",
-                "candidates_before",
-                "guess",
-                "pattern",
-                "success_on_turn",
-                "is_probe",
-                "score_name",
-                "score_value",
-                "topk",
-                "extras",
-            ]
-        )
+    TURNLOG_CSV.parent.mkdir(parents=True, exist_ok=True)
+    file_exists = TURNLOG_CSV.exists()
+    with open(TURNLOG_CSV, "a", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=list(row.keys()))
+        if not file_exists:
+            writer.writeheader()
+        writer.writerow(row)
 
 
-def _append_turn_log(game_id, solver, turn, target, cand_before, guess, patt, success_on_turn):
-    """Append a row to the turn log if logging is enabled."""
-
-    cfg = get_config()
-    if not cfg["analysis"]["log_turns"]:
-        return
-    _maybe_init_turnlog()
-    d = solver.diag() if hasattr(solver, "diag") else {}
-    pattern_str = "".join(str(x) for x in patt)
-    with open(_turnlog_csv(), "a", newline="") as f:
-        w = csv.writer(f)
-        w.writerow(
-            [
-                game_id,
-                solver.name,
-                turn,
-                target,
-                cand_before,
-                guess,
-                pattern_str,
-                int(bool(success_on_turn)),
-                int(d.get("is_probe")) if d.get("is_probe") is not None else "",
-                d.get("score_name"),
-                d.get("score_value"),
-                json.dumps(d.get("topk", [])),
-                json.dumps(d.get("extras", {})),
-            ]
-        )
+# --- helper for profile suffixing like games_fast.csv ---
+def _with_suffix(base: Path, suffix: str) -> Path:
+    if base.suffix != ".csv":
+        return base
+    return base.with_name(f"{base.stem}_{suffix}.csv")
 
 
-def play_game(target: str, solver: Solver, *, hard_mode: bool = False, allow_probes: bool = True, game_id: int | None = None) -> GameResult:
-    """Play a single game of Wordle with ``solver`` against ``target``."""
-
+# --- play a single game ---
+def play_game(
+    target: str,
+    solver: Solver,
+    *,
+    hard_mode: bool = False,
+    allow_probes: bool = True,
+    game_id: int | None = None,
+):
     candidates = list(target_words)
     history = []
-    sequence: List[str] = []
+    sequence: list[str] = []
     solver.reset()
 
     for turn in range(1, 7):
         cand_before = len(candidates)
-        guess = solver.guess(candidates, all_valid_words if allow_probes else candidates, history, hard_mode)
+        guess = solver.guess(
+            candidates,
+            all_valid_words if allow_probes else candidates,
+            history,
+            hard_mode,
+        )
         sequence.append(guess)
         patt = cached_pattern(guess, target)
         history.append((guess, patt))
-        _append_turn_log(game_id, solver, turn, target, cand_before, guess, patt, guess == target)
+        append_turn_log(
+            {
+                "game_id": game_id,
+                "solver": solver.name,
+                "turn": turn,
+                "target": target,
+                "candidates_before": cand_before,
+                "guess": guess,
+                "pattern": "".join(str(x) for x in patt),
+                "success_on_turn": int(guess == target),
+            }
+        )
         if guess == target:
-            return GameResult(solver=solver.name, target=target, success=True, guesses=turn, sequence=sequence)
+            return {
+                "solver": solver.name,
+                "target": target,
+                "success": 1,
+                "guesses": turn,
+                "sequence": " ".join(sequence),
+            }
         candidates = [w for w in candidates if consistent(w, guess, patt)]
-    return GameResult(solver=solver.name, target=target, success=False, guesses=6, sequence=sequence)
+
+    return {
+        "solver": solver.name,
+        "target": target,
+        "success": 0,
+        "guesses": 6,
+        "sequence": " ".join(sequence),
+    }
 
 
-def run_benchmark(solvers: List[Solver], mode: str | None = None):
-    """Run a suite of games for ``solvers``.
+# --- run_benchmark: write per-game + metrics, 2 d.p., profile-aware ---
+def run_benchmark(
+    solvers,
+    *,
+    mode: str = "smoke",
+    results_dir: Path = RESULTS_DIR,
+    log_turns: bool = LOG_TURNS,
+    n_targets: int | str | None = None,
+    repeats: int = 1,
+):
+    global RESULTS_DIR, GAMES_CSV, METRICS_CSV, TURNLOG_CSV, LOG_TURNS
+    RESULTS_DIR = Path(results_dir)
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 
-    Returns a tuple ``(rows, metrics)`` where ``rows`` is a list of
-    :class:`GameResult` and ``metrics`` is a list of summary dictionaries
-    written to ``results/summary``.
-    """
+    LOG_TURNS = bool(log_turns)
+    TURNLOG_CSV = RESULTS_DIR / f"turnlog_{mode}.csv"
+    GAMES_CSV = _with_suffix(RESULTS_DIR / "games.csv", mode)
+    METRICS_CSV = _with_suffix(RESULTS_DIR / "metrics.csv", mode)
 
-    cfg = get_config()
-    mode = mode or cfg["mode"]
-    if mode == "fast":
-        subset = random.sample(target_words, k=min(cfg["fast_n_targets"], len(target_words)))
-        repeats = cfg["fast_repeats"]
+    if n_targets in (None, "all"):
+        targets = list(target_words)
     else:
-        subset = list(target_words)
-        repeats = cfg["full_repeats"]
+        targets = random.sample(list(target_words), k=min(int(n_targets), len(target_words)))
 
-    total_games = len(solvers) * repeats * len(subset)
-    pbar = tqdm(total=total_games, desc=f"Running {mode} benchmark", ncols=100)
-
-    rows: List[GameResult] = []
+    rows: list[dict] = []
     gid = 0
     for solver in solvers:
         for _ in range(repeats):
-            for target in subset:
+            for target in targets:
                 gid += 1
-                res = play_game(
-                    target,
-                    solver,
-                    hard_mode=cfg["hard_mode"],
-                    allow_probes=cfg["allow_probes"],
-                    game_id=gid,
-                )
-                rows.append(res)
-                pbar.update(1)
-    pbar.close()
+                row = play_game(target, solver, game_id=gid)
+                rows.append(row)
 
-    # Write per-game CSV
-    summary_dir = _summary_dir()
-    os.makedirs(summary_dir, exist_ok=True)
-    games_csv = os.path.join(summary_dir, f"games_{mode}.csv")
-    with open(games_csv, "w", newline="") as f:
-        w = csv.writer(f)
-        w.writerow(["solver", "target", "success", "guesses", "sequence"])
-        for r in rows:
-            w.writerow([r.solver, r.target, int(r.success), r.guesses, " ".join(r.sequence)])
-    print("Wrote:", games_csv)
+    games_df = pd.DataFrame(rows)
+    games_df.to_csv(GAMES_CSV, index=False, float_format="%.2f")
 
-    # Aggregate metrics per solver
-    metrics = []
-    for name, group in itertools.groupby(sorted(rows, key=lambda x: x.solver), key=lambda x: x.solver):
-        g = list(group)
-        n = len(g)
-        wins = sum(r.success for r in g)
-        win_rate = 100 * wins / n if n else 0.0
-        avg_guesses = statistics.mean([r.guesses for r in g if r.success]) if wins else float("nan")
-        dist = collections.Counter(r.guesses for r in g if r.success)
-        row = {
-            "solver": name,
-            "n_games": n,
-            "win_rate": win_rate,
-            "avg_guesses_success": avg_guesses,
-            "fail_rate": 100 - win_rate,
-            "p_solved_2": dist.get(2, 0) / n,
-            "p_solved_3": dist.get(3, 0) / n,
-            "p_solved_4": dist.get(4, 0) / n,
-            "p_solved_5": dist.get(5, 0) / n,
-            "p_solved_6": dist.get(6, 0) / n,
-        }
-        metrics.append(row)
+    agg = (
+        games_df.groupby("solver", dropna=False)
+        .agg(
+            n_games=("success", "size"),
+            win_rate=("success", "mean"),
+            avg_guesses=("guesses", "mean"),
+            fail_rate=("success", lambda s: 1 - s.mean()),
+        )
+        .reset_index()
+    )
 
-    metrics_csv = os.path.join(summary_dir, f"metrics_{mode}.csv")
-    with open(metrics_csv, "w", newline="") as f:
-        w = csv.DictWriter(f, fieldnames=list(metrics[0].keys()))
-        w.writeheader()
-        w.writerows(metrics)
-    print("Wrote:", metrics_csv)
+    for k in (2, 3, 4, 5, 6):
+        col = f"p_solved_{k}"
+        sub = games_df.loc[games_df["success"] == 1, ["solver", "guesses"]].copy()
+        sub["hit"] = (sub["guesses"] == k).astype(float)
+        agg = agg.merge(
+            sub.groupby("solver", dropna=False)["hit"].mean().rename(col),
+            on="solver",
+            how="left",
+        )
 
-    return rows, metrics
+    agg = agg.fillna(0.0)
+    agg.to_csv(METRICS_CSV, index=False, float_format="%.2f")
+
+    return rows, {"games_csv": str(GAMES_CSV), "metrics_csv": str(METRICS_CSV)}
 
 
-# ---------------------------------------------------------------------------
-#  Summary with bootstrap confidence intervals
+# --- lightweight bootstrap CIs for solver-level metrics ---
+def _bootstrap_ci(
+    x: np.ndarray,
+    stat_fn,
+    n_boot: int = 2000,
+    ci: float = 0.95,
+    seed: int = 42,
+):
+    x = np.asarray(x, dtype=float)
+    if x.size == 0:
+        return (np.nan, np.nan)
+    rng = np.random.default_rng(seed)
+    n = x.size
+    stats = np.empty(n_boot, dtype=float)
+    for i in range(n_boot):
+        sample = x[rng.integers(0, n, n)]
+        stats[i] = stat_fn(sample)
+    lo = np.quantile(stats, (1 - ci) / 2)
+    hi = np.quantile(stats, 1 - (1 - ci) / 2)
+    return (lo, hi)
 
 
-def _bootstrap_ci(samples: np.ndarray, fn, *, B: int = 2000, alpha: float = 0.05, rng=None):
-    rng = rng or np.random.default_rng(0)
-    n = len(samples)
-    stats = []
-    for _ in range(B):
-        idx = rng.integers(0, n, n)
-        stats.append(fn(samples[idx]))
-    stats.sort()
-    lo = stats[int((alpha / 2) * B)]
-    hi = stats[int((1 - alpha / 2) * B)]
-    return lo, hi
-
-
-def summarize_with_cis(rows: List[GameResult]) -> pd.DataFrame:
-    """Aggregate ``rows`` with bootstrap confidence intervals.
-
-    A CSV is written to ``results/summary`` and the resulting DataFrame is
-    returned.  This function mirrors the behaviour of the original
-    notebook but is safe to import from the command line interface.
-    """
-
-    by_solver: dict[str, List[GameResult]] = collections.defaultdict(list)
-    for r in rows:
-        by_solver[r.solver].append(r)
+def summarize_with_cis(
+    input_csv: str,
+    output_csv: str | None = None,
+    n_boot: int = 2000,
+    ci: float = 0.95,
+    group_cols=("solver",),
+):
+    df = pd.read_csv(input_csv)
+    if isinstance(group_cols, str):
+        group_cols = (group_cols,)
 
     out = []
-    for solver, lst in by_solver.items():
-        succ = np.array([int(r.success) for r in lst])
-        wr = succ.mean() * 100
-        wr_lo, wr_hi = _bootstrap_ci(succ, np.mean)
-        wr_lo *= 100
-        wr_hi *= 100
+    for keys, g in df.groupby(list(group_cols), dropna=False):
+        if not isinstance(keys, tuple):
+            keys = (keys,)
 
-        gsucc = np.array([r.guesses for r in lst if r.success])
-        if len(gsucc):
-            avg = gsucc.mean()
-            avg_lo, avg_hi = _bootstrap_ci(gsucc, np.mean)
-        else:
-            avg = float("nan")
-            avg_lo = avg_hi = float("nan")
+        win = g["success"].astype(float).to_numpy()
+        wr = float(win.mean()) if win.size else np.nan
+        wr_lo, wr_hi = _bootstrap_ci(win, np.mean, n_boot=n_boot, ci=ci)
+
+        solved = g.loc[g["success"] == 1, "guesses"].astype(float).to_numpy()
+        ag = float(solved.mean()) if solved.size else np.nan
+        ag_lo, ag_hi = (
+            _bootstrap_ci(solved, np.mean, n_boot=n_boot, ci=ci) if solved.size else (np.nan, np.nan)
+        )
 
         out.append(
             {
-                "solver": solver,
+                **{c: v for c, v in zip(group_cols, keys)},
+                "n_games": int(len(g)),
                 "win_rate": wr,
                 "win_rate_lo": wr_lo,
                 "win_rate_hi": wr_hi,
-                "avg_guesses": avg,
-                "avg_lo": avg_lo,
-                "avg_hi": avg_hi,
+                "avg_guesses": ag,
+                "avg_guesses_lo": ag_lo,
+                "avg_guesses_hi": ag_hi,
             }
         )
 
-    df = pd.DataFrame(out)
-    cfg = get_config()
-    path = os.path.join(_summary_dir(), f"metrics_with_cis_{cfg['mode']}.csv")
-    df.to_csv(path, index=False)
-    print("Wrote:", path)
-    return df
+    out = pd.DataFrame(out).sort_values(list(group_cols)).reset_index(drop=True)
 
+    if output_csv is None:
+        inp = Path(input_csv)
+        suffix = inp.stem.split("_")[-1] if "_" in inp.stem else "smoke"
+        output_csv = inp.parent / f"metrics_with_cis_{suffix}.csv"
+
+    out.to_csv(output_csv, index=False, float_format="%.2f")
+    return out
+
+
+__all__ = [
+    "run_benchmark",
+    "summarize_with_cis",
+    "append_turn_log",
+    "play_game",
+]
 

--- a/src/figures.py
+++ b/src/figures.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+def build_all(mode="smoke", results_dir="results/summary"):
+    rd = Path(results_dir)
+    metrics = rd / f"metrics_{mode}.csv"
+    metrics_ci = rd / f"metrics_with_cis_{mode}.csv"
+
+    if not metrics.exists():
+        print(f"[figures] {metrics.name} not found — skipping.")
+        return
+
+    df = pd.read_csv(metrics)
+    df_ci = pd.read_csv(metrics_ci) if metrics_ci.exists() else None
+
+    plots_dir = Path("results/plots")
+    plots_dir.mkdir(parents=True, exist_ok=True)
+
+    # simple bar chart example
+    fig, ax = plt.subplots(figsize=(6, 4))
+    ax.bar(df["solver"], df["avg_guesses"])
+
+    if df_ci is not None:
+        errs = [
+            df_ci.loc[df_ci["solver"] == s, "avg_guesses_hi"].values[0]
+            - df_ci.loc[df_ci["solver"] == s, "avg_guesses"].values[0]
+            for s in df["solver"]
+        ]
+        ax.errorbar(df["solver"], df["avg_guesses"], yerr=errs, fmt="none", ecolor="black")
+
+    ax.set_ylabel("Average guesses")
+    ax.set_title("Avg guesses by solver")
+    fig.tight_layout()
+    fig.savefig(plots_dir / f"solver_bars_{mode}.png", dpi=200)
+
+
+__all__ = ["build_all"]
+


### PR DESCRIPTION
## Summary
- refactor evaluation to log turns, suffix result files by profile, format floats to 2 decimals, and compute bootstrap confidence intervals
- add profile runner and CLI with configurable logging, CI output, and plots
- add tolerant figure generation and profile YAMLs; document profiles and outputs

## Testing
- `find src -type d -name "__pycache__" -exec rm -rf {} +`
- `python -m venv .venv && source .venv/bin/activate`
- `pip install -r requirements.txt`
- `python -m src.cli run --profile smoke`
- `python -m src.cli run --profile fast` *(fails: long runtime)*
- `python -m src.cli figures --profile fast` *(skipped: metrics_fast.csv not found)*
- `python -m src.cli run --profile full` *(fails: long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68acc3ccb98c832cbe3f7fac204cee40