### PR TITLE
Add benchmark GUI for selecting solvers and profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ pip install -r requirements.txt
 ```
 
 ### GUI
-Run a simple desktop interface for interactive solving:
+Run a simple desktop interface to benchmark selected solvers:
 
 ```bash
 python -m src.gui

--- a/src/gui.py
+++ b/src/gui.py
@@ -1,72 +1,60 @@
 import tkinter as tk
 from tkinter import ttk, messagebox
+from pathlib import Path
 
-from .solvers import (
-    RandomSolver,
-    HeuristicSolver,
-    PositionalHeuristicSolver,
-    EntropySolver,
-    MCTSSolver,
-)
-from .wordle_core import feedback_pattern, next_candidates, target_words, valid_words
-
-SOLVER_OPTIONS = {
-    "Random": RandomSolver,
-    "Heuristic": HeuristicSolver,
-    "Positional": PositionalHeuristicSolver,
-    "Entropy": EntropySolver,
-    "MCTS": MCTSSolver,
-}
-
-
-def solve_word(solver_cls, target: str):
-    candidates = target_words.copy()
-    valid = list(valid_words)
-    history = []
-    solver = solver_cls()
-    solver.reset()
-    for _ in range(6):
-        guess = solver.guess(candidates, valid, history, hard_mode=False)
-        patt = feedback_pattern(guess, target)
-        history.append((guess, ''.join(str(x) for x in patt)))
-        if all(v == 2 for v in patt):
-            break
-        candidates = next_candidates(candidates, guess, patt)
-    return history
+from .runner import SOLVER_REGISTRY, run_profile
 
 
 def run_gui():
     root = tk.Tk()
-    root.title("Wordle Solver")
+    root.title("Wordle Benchmark")
 
-    solver_var = tk.StringVar(value="Heuristic")
-    tk.Label(root, text="Solver:").grid(row=0, column=0, sticky="w")
-    solver_menu = ttk.Combobox(root, textvariable=solver_var, values=list(SOLVER_OPTIONS.keys()), state="readonly")
-    solver_menu.grid(row=0, column=1, sticky="we")
+    tk.Label(root, text="Solvers:").grid(row=0, column=0, sticky="nw")
+    solver_vars: dict[str, tk.BooleanVar] = {}
+    for i, name in enumerate(SOLVER_REGISTRY.keys(), start=1):
+        var = tk.BooleanVar(value=False)
+        solver_vars[name] = var
+        tk.Checkbutton(root, text=name, variable=var).grid(row=i, column=0, sticky="w")
 
-    tk.Label(root, text="Target word:").grid(row=1, column=0, sticky="w")
-    target_entry = tk.Entry(root)
-    target_entry.grid(row=1, column=1, sticky="we")
+    tk.Label(root, text="Profile:").grid(row=0, column=1, sticky="w")
+    profile_var = tk.StringVar(value="smoke")
+    profile_menu = ttk.Combobox(
+        root, textvariable=profile_var, values=["smoke", "full"], state="readonly"
+    )
+    profile_menu.grid(row=0, column=2, sticky="we")
 
-    output = tk.Text(root, height=10, width=40)
-    output.grid(row=3, column=0, columnspan=2, padx=5, pady=5)
+    output = tk.Text(root, height=15, width=60)
+    output.grid(row=len(SOLVER_REGISTRY) + 1, column=0, columnspan=3, padx=5, pady=5)
 
-    def on_solve():
-        target = target_entry.get().strip().lower()
-        if len(target) != 5 or target not in target_words:
-            messagebox.showerror("Error", "Please enter a valid 5-letter word.")
+    def on_run():
+        selected = [name for name, var in solver_vars.items() if var.get()]
+        if not selected:
+            messagebox.showerror("Error", "Select at least one solver")
             return
-        solver_cls = SOLVER_OPTIONS[solver_var.get()]
-        hist = solve_word(solver_cls, target)
         output.delete("1.0", tk.END)
-        for turn, (guess, patt) in enumerate(hist, 1):
-            output.insert(tk.END, f"{turn}: {guess} {patt}\n")
+        output.insert(
+            tk.END,
+            f"Running profile '{profile_var.get()}' for: {', '.join(selected)}\n",
+        )
+        try:
+            meta = run_profile(profile_var.get(), solvers=selected)
+            metrics_csv = Path(meta["metrics_csv"])
+            output.insert(tk.END, f"Results written to {metrics_csv}\n\n")
+            try:
+                output.insert(tk.END, metrics_csv.read_text())
+            except Exception:
+                pass
+        except Exception as e:
+            messagebox.showerror("Error", str(e))
 
-    tk.Button(root, text="Solve", command=on_solve).grid(row=2, column=0, columnspan=2, pady=5)
+    tk.Button(root, text="Run", command=on_run).grid(
+        row=len(SOLVER_REGISTRY) + 2, column=0, columnspan=3, pady=5
+    )
 
-    root.columnconfigure(1, weight=1)
+    root.columnconfigure(2, weight=1)
     root.mainloop()
 
 
 if __name__ == "__main__":
     run_gui()
+

--- a/src/runner.py
+++ b/src/runner.py
@@ -32,10 +32,12 @@ def build_solvers_from_config(cfg: dict):
     return solvers
 
 
-def run_profile(profile_name: str):
+def run_profile(profile_name: str, solvers: list[str] | None = None):
     cfg_path = Path("config") / f"{profile_name}.yaml"
     with open(cfg_path) as f:
         CONFIG = yaml.safe_load(f) or {}
+    if solvers is not None:
+        CONFIG["solvers"] = solvers
 
     # propagate config for solvers that consult global settings
     set_config(CONFIG)
@@ -51,10 +53,10 @@ def run_profile(profile_name: str):
     n_targets = CONFIG.get("n_targets")
     repeats = int(CONFIG.get("repeats", 1))
 
-    solvers = build_solvers_from_config(CONFIG)
+    solver_objs = build_solvers_from_config(CONFIG)
 
     rows, meta = run_benchmark(
-        solvers,
+        solver_objs,
         mode=mode,
         results_dir=results_dir,
         log_turns=log_turns,
@@ -73,6 +75,8 @@ def run_profile(profile_name: str):
 
         build_all(mode=mode, results_dir=str(results_dir))
 
+    return meta
 
-__all__ = ["run_profile"]
+
+__all__ = ["run_profile", "SOLVER_REGISTRY", "build_solvers_from_config"]
 


### PR DESCRIPTION
 Summary
- Provide a new GUI to choose solvers and run smoke/full benchmarks
- Extend `run_profile` to accept a solver list and return metadata
- Update README to describe the new benchmarking GUI

 Testing
- `pytest`
- `python -m src.cli run --profile smoke`


