### PR TITLE
Add comprehensive smoke/full configs and runtime reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ python -m src.gui
 ```
 
 ### Profiles
-- **Smoke** (seconds): sanity-check the pipeline  
+- **Smoke**: quick check across all solvers on a small random target subset. Heavy solvers use a
+  reduced search (fewer MCTS rollouts and capped entropy candidates) to finish in seconds.
   `python -m src.cli run --profile smoke`
 
-- **Fast** (dev benchmark; with 95% CIs + plots):  
-  `python -m src.cli run --profile fast`
-
-- **Full** (full 2309-word sweep; with 95% CIs + plots):
+- **Full**: exhaustive 2309-word sweep using all solvers with repeated runs for accuracy
   `python -m src.cli run --profile full`
+
+After each profile completes, the CLI reports the total runtime.
 
 ### Outputs
 `results/summary/`
@@ -36,7 +36,7 @@ python -m src.gui
 After running a benchmark you can compare solvers using paired tests:
 
 ```bash
-python -m src.stats results/summary/games_fast.csv --metric guesses --test wilcoxon
+python -m src.stats results/summary/games_full.csv --metric guesses --test wilcoxon
 ```
 This writes a table of pairwise test statistics and p-values comparing solver performance.
 

--- a/config/full.yaml
+++ b/config/full.yaml
@@ -1,8 +1,10 @@
 mode: full
+# Exhaustive benchmark over the full target list
 n_targets: all
-repeats: 1
+# More repeats give more stable statistics
+repeats: 10
 workers: 1
-solvers: ["random", "heuristic", "entropy"]
+solvers: ["random", "heuristic", "positional", "entropy", "mcts"]
 log_turns: false
 write_ci: true
 make_plots: true

--- a/config/smoke.yaml
+++ b/config/smoke.yaml
@@ -1,10 +1,16 @@
 mode: smoke
-n_targets: 10
+# Quick check across all solvers using a small subset of targets
+n_targets: 20
 repeats: 1
 workers: 1
-solvers: ["random"]
+solvers: ["random", "heuristic", "positional", "entropy", "mcts"]
 log_turns: false
-write_ci: false
-make_plots: false
+allow_probes: false
+mcts:
+  rollouts_per_move: 5
+entropy_max_candidates: 500
+# Produce confidence intervals and figures for basic verification
+write_ci: true
+make_plots: true
 results_dir: results/summary
 

--- a/src/config.py
+++ b/src/config.py
@@ -17,6 +17,7 @@ CONFIG_DEFAULTS = {
     "full_repeats": 1,
     "hard_mode": False,
     "allow_probes": True,
+    "entropy_max_candidates": 2000,
     "mcts": {"rollouts_per_move": 100, "ucb_c": 1.4},
     "analysis": {"log_turns": True, "topk": 10},
 }

--- a/src/eval.py
+++ b/src/eval.py
@@ -111,6 +111,8 @@ def run_benchmark(
     log_turns: bool = LOG_TURNS,
     n_targets: int | str | None = None,
     repeats: int = 1,
+    allow_probes: bool = True,
+    hard_mode: bool = False,
 ):
     global RESULTS_DIR, GAMES_CSV, METRICS_CSV, TURNLOG_CSV, LOG_TURNS
     RESULTS_DIR = Path(results_dir)
@@ -132,7 +134,13 @@ def run_benchmark(
         for _ in range(repeats):
             for target in targets:
                 gid += 1
-                row = play_game(target, solver, game_id=gid)
+                row = play_game(
+                    target,
+                    solver,
+                    hard_mode=hard_mode,
+                    allow_probes=allow_probes,
+                    game_id=gid,
+                )
                 rows.append(row)
 
     games_df = pd.DataFrame(rows)

--- a/src/runner.py
+++ b/src/runner.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import time
 import yaml
 
 from .eval import run_benchmark, summarize_with_cis
@@ -50,9 +51,12 @@ def run_profile(profile_name: str):
 
     n_targets = CONFIG.get("n_targets")
     repeats = int(CONFIG.get("repeats", 1))
+    allow_probes = bool(CONFIG.get("allow_probes", True))
+    hard_mode = bool(CONFIG.get("hard_mode", False))
 
     solvers = build_solvers_from_config(CONFIG)
 
+    start = time.perf_counter()
     rows, meta = run_benchmark(
         solvers,
         mode=mode,
@@ -60,6 +64,8 @@ def run_profile(profile_name: str):
         log_turns=log_turns,
         n_targets=n_targets,
         repeats=repeats,
+        allow_probes=allow_probes,
+        hard_mode=hard_mode,
     )
 
     games_csv = Path(meta["games_csv"])
@@ -72,6 +78,9 @@ def run_profile(profile_name: str):
         from .figures import build_all
 
         build_all(mode=mode, results_dir=str(results_dir))
+
+    elapsed = time.perf_counter() - start
+    print(f"Completed profile '{profile_name}' in {elapsed:.2f} seconds")
 
 
 __all__ = ["run_profile"]

--- a/src/solvers.py
+++ b/src/solvers.py
@@ -96,9 +96,9 @@ class EntropySolver(Solver):
     def guess(self, candidates, valid, history, hard_mode):
         cfg = get_config()
         pool = candidates if (hard_mode or not cfg["allow_probes"]) else all_valid_words
-        K_prune = 2000 if len(pool) > 3000 else len(pool)
-        if K_prune < len(pool):
-            pool = sorted(pool, key=heuristic_score, reverse=True)[:K_prune]
+        max_cand = int(cfg.get("entropy_max_candidates", 2000))
+        if len(pool) > max_cand:
+            pool = sorted(pool, key=heuristic_score, reverse=True)[:max_cand]
         scored = [(g, entropy_of_guess(g, candidates)) for g in pool]
         scored.sort(key=lambda x: x[1], reverse=True)
         best_g, _ = scored[0]


### PR DESCRIPTION
Summary
- expand smoke profile to run all solvers with plots, confidence intervals, and faster heavy-solvers
- expand full profile for accurate benchmarking across all solvers with repeats
- show total runtime after running any profile

 Testing
- `pip install -r requirements.txt`
- `python -m src.cli run --profile smoke`


-